### PR TITLE
Change variable to free module from incoming route

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -60,7 +60,7 @@ function directdid_get_config($engine){
                 $ext->add($contextname, $extension, '', new ext_progress());
                 $ext->add($contextname, $extension, '', new ext_macro('user-callerid'));
                 $ext->add($contextname, $extension, '', new ext_noop('${EXTEN}'));
-                $ext->add($contextname, $extension, '', new ext_goto('directdid-'.$did['id'].'-call,'.$did['prefix'].'${EXTEN:-'.$did['varlength'].'},1'));
+		$ext->add($contextname, $extension, '', new ext_goto('directdid-'.$did['id'].'-call,'.$did['prefix'].'${FROM_DID:-'.$did['varlength'].'},1'));
 
                 $contextname2 = 'directdid-'.$did['id'].'-call';
                 $ext->add($contextname2, $extension2, '', new ext_set('CDR(dst_cnam)','${DB(AMPUSER/${EXTEN}/cidname)}'));


### PR DESCRIPTION
Directdid module only works if it is the first destination of an incoming route because it uses  EXTEN variable to know which extension to forward the call to.
By using FROM_DID variable (it is initialized on each incoming route with the called number) Directdid can be used not only after incoming route but in any step of the incoming configuration.
This allows using, for example, a time condition before.