### PR TITLE
Fix direct pickup with different context

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -65,7 +65,7 @@ function directdid_get_config($engine){
 
                 $contextname2 = 'directdid-'.$did['id'].'-call';
                 $ext->add($contextname2, $extension2, '', new ext_set('CDR(dst_cnam)','${DB(AMPUSER/${EXTEN}/cidname)}'));
-		$ext->add($contextname2, $extension2, '', new ext_set('__PICKUPMARK','${EXTEN}'));
+                $ext->add($contextname2, $extension2, '', new ext_set('__PICKUPMARK','${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_macro('dial',$did['timeout'].',${DIAL_OPTIONS},${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="NOANSWER"]',$did['timeout_destination']));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="BUSY"]',$did['busy_destination']));

--- a/functions.inc.php
+++ b/functions.inc.php
@@ -65,6 +65,7 @@ function directdid_get_config($engine){
 
                 $contextname2 = 'directdid-'.$did['id'].'-call';
                 $ext->add($contextname2, $extension2, '', new ext_set('CDR(dst_cnam)','${DB(AMPUSER/${EXTEN}/cidname)}'));
+		$ext->add($contextname2, $extension2, '', new ext_set('__PICKUPMARK','${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_macro('dial',$did['timeout'].',${DIAL_OPTIONS},${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="NOANSWER"]',$did['timeout_destination']));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="BUSY"]',$did['busy_destination']));


### PR DESCRIPTION
Direct pickup doesn't work for a call from directdid module to an extension with a different context that does direct pickup.
Using PICKUPMARK variable fixes this issue.