### PR TITLE
Fix syntax of GotoIf command

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -67,10 +67,9 @@ function directdid_get_config($engine){
                 $ext->add($contextname2, $extension2, '', new ext_set('CDR(dst_cnam)','${DB(AMPUSER/${EXTEN}/cidname)}'));
                 $ext->add($contextname2, $extension2, '', new ext_set('__PICKUPMARK','${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_macro('dial',$did['timeout'].',${DIAL_OPTIONS},${EXTEN}'));
-                $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="NOANSWER"]',$did['timeout_destination']));
-                $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="BUSY"]',$did['busy_destination']));
-                $ext->add($contextname2, $extension2, '', new ext_gotoif('${DIALSTATUS}"="CHANUNAVAIL"]',$did['unavailable_destination']));
-
+                $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "NOANSWER"]',$did['timeout_destination']));
+                $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "BUSY"]',$did['busy_destination']));
+                $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "CHANUNAVAIL"]',$did['unavailable_destination']));
             }
         break;
     }


### PR DESCRIPTION
Fix syntax of GotoIf command that doesn't work in certain circumstances.
The fail destinations are not correctly respected as the syntax is wrong because it does not make a comparison.
Busy extension:
Wrong

Executing [s@macro-dial:7] NoOp("PJSIP/Sangoma_208e7a_isdn_2-00000004", "Returned from dialparties with no extensions to call and DIALSTATUS: BUSY") in new stack
    -- Executing [s@macro-dial:8] MacroExit("PJSIP/Sangoma_208e7a_isdn_2-00000004", "") in new stack
    -- Executing [298@directdid-1-call:3] GotoIf("PJSIP/Sangoma_208e7a_isdn_2-00000004", "BUSY"="NOANSWER"]?app-blackhole,hangup,1") in new stack
    -- Goto (app-blackhole,hangup,1)

Good

 -- Executing [s@macro-dial:7] NoOp("PJSIP/Sangoma_208e7a_isdn_2-00000009", "Returned from dialparties with no extensions to call and DIALSTATUS: BUSY") in new stack
    -- Executing [s@macro-dial:8] MacroExit("PJSIP/Sangoma_208e7a_isdn_2-00000009", "") in new stack
    -- Executing [298@directdid-1-call:3] GotoIf("PJSIP/Sangoma_208e7a_isdn_2-00000009", "0?app-blackhole,hangup,1") in new stack
    -- Executing [298@directdid-1-call:4] GotoIf("PJSIP/Sangoma_208e7a_isdn_2-00000009", "1?app-blackhole,busy,1") in new stack
    -- Goto (app-blackhole,busy,1)


