### PR TITLE
Use macro-dial-one instead of macro-dial

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -66,7 +66,7 @@ function directdid_get_config($engine){
                 $contextname2 = 'directdid-'.$did['id'].'-call';
                 $ext->add($contextname2, $extension2, '', new ext_set('CDR(dst_cnam)','${DB(AMPUSER/${EXTEN}/cidname)}'));
                 $ext->add($contextname2, $extension2, '', new ext_set('__PICKUPMARK','${EXTEN}'));
-                $ext->add($contextname2, $extension2, '', new ext_macro('dial',$did['timeout'].',${DIAL_OPTIONS},${EXTEN}'));
+                $ext->add($contextname2, $extension2, '', new ext_macro('dial-one',$did['timeout'].',${DIAL_OPTIONS},${EXTEN}'));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "NOANSWER"]',$did['timeout_destination']));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "BUSY"]',$did['busy_destination']));
                 $ext->add($contextname2, $extension2, '', new ext_gotoif('$["${DIALSTATUS}" = "CHANUNAVAIL"]',$did['unavailable_destination']));


### PR DESCRIPTION
Use macro-dial-one instead of macro-dial because is more appropriate because macro-dial-one is used when dialing a single extension.
